### PR TITLE
[local ?] products の全件取得をやめる

### DIFF
--- a/webapp/backend/go.mod
+++ b/webapp/backend/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/jmoiron/sqlx v1.4.0
 	github.com/kaz/pprotein v1.2.4
 	github.com/riandyrn/otelchi v0.12.1
+	github.com/samber/lo v1.51.0
 	go.opentelemetry.io/otel v1.36.0
 	go.opentelemetry.io/otel/exporters/jaeger v1.17.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.28.0

--- a/webapp/backend/go.sum
+++ b/webapp/backend/go.sum
@@ -112,6 +112,8 @@ github.com/riandyrn/otelchi v0.12.1 h1:FdRKK3/RgZ/T+d+qTH5Uw3MFx0KwRF38SkdfTMMq/
 github.com/riandyrn/otelchi v0.12.1/go.mod h1:weZZeUJURvtCcbWsdb7Y6F8KFZGedJlSrgUjq9VirV8=
 github.com/rogpeppe/go-internal v1.13.1 h1:KvO1DLK/DRN07sQ1LQKScxyZJuNnedQ5/wKSR38lUII=
 github.com/rogpeppe/go-internal v1.13.1/go.mod h1:uMEvuHeurkdAXX61udpOXGD/AzZDWNMNyH2VO9fmH0o=
+github.com/samber/lo v1.51.0 h1:kysRYLbHy/MB7kQZf5DSN50JHmMsNEdeY24VzJFu7wI=
+github.com/samber/lo v1.51.0/go.mod h1:4+MXEGsJzbKGaUEQFKBq2xtfuznW9oz/WrgyzMzRoM0=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 h1:n661drycOFuPLCN3Uc8sB6B/s6Z4t2xvBgU1htSHuq8=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3/go.mod h1:A0bzQcvG0E7Rwjx0REVgAGH58e96+X0MeOfepqsbeW4=
 github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=

--- a/webapp/mysql/migration/0_sample.sql
+++ b/webapp/mysql/migration/0_sample.sql
@@ -1,1 +1,8 @@
 -- このファイルに記述されたSQLコマンドが、マイグレーション時に実行されます。
+ALTER TABLE products
+    ADD INDEX idx_products_name_product_id (name, product_id),
+    ADD INDEX idx_products_name_desc_product_id (name DESC, product_id),
+    ADD INDEX idx_products_value_product_id (value, product_id),
+    ADD INDEX idx_products_value_desc_product_id (value DESC, product_id),
+    ADD INDEX idx_products_weight_product_id (weight, product_id),
+    ADD INDEX idx_products_weight_desc_product_id (weight DESC, product_id);


### PR DESCRIPTION
## 問題
htop などを見ると mysql の CPU 使用率が支配的なことが分かる。
クエリの高速化 & CPU 負荷の軽減をする必要がある。

スロークエリを query time で並び替えると以下の通り。

<img width="1758" height="139" alt="スクリーンショット 2025-09-28 20 30 35" src="https://github.com/user-attachments/assets/5ef5121a-fd45-4348-9ad5-ebb7a70b56e3" />

回数が多く、平均実行時間も長い。rows examined から処理する行数が多いことが分かる。
実際、クエリは limit もなしの全件取得になっている。

## 実装方針
クエリを発行するのは `ProductRepository` の `ListProducts`。
全件取得 → app で絞り込みを行っている。

つまり、全件取得する必要はない。
クエリで必要な件数だけ絞り込めばよい。

ただし、検索文字列に該当する商品の数のカウントを忘れずに。